### PR TITLE
Cors fixes

### DIFF
--- a/livestream/Controllers/CmafProxyController.cs
+++ b/livestream/Controllers/CmafProxyController.cs
@@ -1,6 +1,5 @@
 using LivestreamFunctions.Model;
 using LivestreamFunctions.Services;
-using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
@@ -52,7 +51,6 @@ namespace LivestreamFunctions
         }
 
         [HttpGet("top-level")]
-        [EnableCors("All")]
         public async Task<IActionResult> GetTopLevelManifest(string token, string url, bool audio_only = false, string language = null)
         {
             if (string.IsNullOrEmpty(token))
@@ -101,7 +99,6 @@ namespace LivestreamFunctions
 
 
         [HttpGet("second-level")]
-        [EnableCors("All")]
         public async Task<IActionResult> GetSecondLevelManifest(string url)
         {
             var keyDeliveryBaseUrl = $"{Request.Scheme}://{Request.Host}/api/keydelivery";

--- a/livestream/Controllers/HlsProxyController.cs
+++ b/livestream/Controllers/HlsProxyController.cs
@@ -1,6 +1,5 @@
 using LivestreamFunctions.Model;
 using LivestreamFunctions.Services;
-using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
@@ -43,7 +42,6 @@ namespace LivestreamFunctions
         }
 
         [HttpGet("top-level")]
-        [EnableCors("All")]
         public async Task<IActionResult> GetTopLevelManifest(string token, string playback_url = null, bool audio_only = false, string language = null)
         {
             if (string.IsNullOrEmpty(token))
@@ -80,7 +78,6 @@ namespace LivestreamFunctions
         }
 
         [HttpGet("second-level")]
-        [EnableCors("All")]
         public async Task<IActionResult> GetSecondLevelManifest(string token, string url)
         {
             var allowedHost = new Uri(_liveOptions.HlsUrl).Host.ToLower();

--- a/livestream/Controllers/KeyController.cs
+++ b/livestream/Controllers/KeyController.cs
@@ -1,5 +1,4 @@
 using LivestreamFunctions.Services;
-using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.IdentityModel.Tokens;
 using Newtonsoft.Json;
@@ -24,7 +23,6 @@ namespace LivestreamFunctions
         }
 
         [HttpGet("{keyGroup}/{keyId}")]
-        [EnableCors("All")]
         public async Task<IActionResult> GetByKeyAndGroup(string keyGroup, string keyId, string token)
         {
             if (string.IsNullOrEmpty(keyGroup) || string.IsNullOrEmpty(keyId) || string.IsNullOrEmpty(token))
@@ -45,7 +43,6 @@ namespace LivestreamFunctions
         [HttpPost]
         [HttpGet]
         [Route("/api/widevine/getLicense")]
-        [EnableCors("All")]
         public async Task<IActionResult> GetLicense(string token)
         {
             var json = await new StreamReader(Request.Body).ReadToEndAsync();

--- a/livestream/Controllers/UrlController.cs
+++ b/livestream/Controllers/UrlController.cs
@@ -2,7 +2,6 @@ using LivestreamFunctions.Model;
 using LivestreamFunctions.Services;
 using Microsoft.AspNetCore.Authorization;
 using System.Web;
-using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using System;

--- a/livestream/Controllers/UrlController.cs
+++ b/livestream/Controllers/UrlController.cs
@@ -28,7 +28,6 @@ namespace LivestreamFunctions
         }
 
         [HttpGet("live")]
-        [EnableCors("All")]
         public ActionResult<UrlDto> GetHls(string experiment = null)
         {
             if (_liveOptions.Value.UsePureUrl) {
@@ -67,7 +66,6 @@ namespace LivestreamFunctions
         }
 
         [HttpGet("live-audio")]
-        [EnableCors("All")]
         public ActionResult<UrlDto> GetLiveAudioOnlyUrl(string language = null)
         {
             var url = Url.Action("GetTopLevelManifest", "CmafProxy", null, Request.Scheme);

--- a/livestream/Startup.cs
+++ b/livestream/Startup.cs
@@ -69,11 +69,7 @@ namespace LivestreamFunctions
             services.AddSingleton<IAmazonS3>((s) => new AmazonS3Client(awsCredentials, RegionEndpoint.EUNorth1));
             services.AddSingleton<IAmazonCloudFront>((s) => new AmazonCloudFrontClient(awsCredentials, RegionEndpoint.EUNorth1));
             services.AddSingleton((s) => new UrlSigner(s.GetRequiredService<IAmazonCloudFront>(), privateKey, keyPairId));
-            services.AddCors(options => {
-                options.AddPolicy("All", builder => {
-                    builder.AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader();
-                });
-            });
+            services.AddCors();
 
             services.AddAuthorization(options => {
                 options.DefaultPolicy = new AuthorizationPolicyBuilder()

--- a/livestream/Startup.cs
+++ b/livestream/Startup.cs
@@ -128,7 +128,10 @@ namespace LivestreamFunctions
             app.UseRouting();
             app.UseAuthentication();
             app.UseAuthorization();
-            app.UseCors();
+            app.UseCors(builder =>
+            {
+                builder.AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader();
+            });
             app.UseEndpoints(endpoints => {
                 endpoints.MapControllers();
             });


### PR DESCRIPTION
Fixes preflight requests which currently get blocked for /api/urls/live.
Issue: 
- Preflight (OPTIONS) requests gets 401 "unauthorized" and 405 "method not allowed".
- 401 because the CORS stuff was currently at the endpoint level, but the /urls/live endpoint has `[Authorize]` and preflight requests doesn't include Authorization headers.
- 405 don't know why this happens, but removing attribute-based cors fixes this too.

Remember to:
- Test chromecast, which is currently the only browser-based playback that uses this service (the current brunstad.tv backend creates live-urls itself and doesn't play through the proxy)